### PR TITLE
[Lab5] Add tx err monitor orch

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -117,7 +117,8 @@ orchagent_SOURCES = \
             dash/dashtagmgr.cpp \
             dash/pbutils.cpp \
             twamporch.cpp \
-            stporch.cpp
+            stporch.cpp \
+            txerrmonorch.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp flex_counter/flow_counter_handler.cpp flex_counter/flowcounterrouteorch.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -65,6 +65,7 @@ MonitorOrch *gMonitorOrch;
 TunnelDecapOrch *gTunneldecapOrch;
 StpOrch *gStpOrch;
 MuxOrch *gMuxOrch;
+TxErrMonOrch *gTxErrMonOrch;
 
 bool gIsNatSupported = false;
 event_handle_t g_events_handle;
@@ -482,6 +483,8 @@ bool OrchDaemon::init()
 
     gNhgMapOrch = new NhgMapOrch(m_applDb, APP_FC_TO_NHG_INDEX_MAP_TABLE_NAME);
 
+    gTxErrMonOrch = new TxErrMonOrch(m_configDb);
+
     /*
      * The order of the orch list is important for state restore of warm start and
      * the queued processing in m_toSync map after gPortsOrch->allPortsReady() is set.
@@ -490,7 +493,7 @@ bool OrchDaemon::init()
      * when iterating ConsumerMap. This is ensured implicitly by the order of keys in ordered map.
      * For cases when Orch has to process tables in specific order, like PortsOrch during warm start, it has to override Orch::doTask()
      */
-    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, gTunneldecapOrch, sflow_orch, gDebugCounterOrch, gMacsecOrch, bgp_global_state_orch, gBfdOrch, gSrv6Orch, gMuxOrch, mux_cb_orch, gMonitorOrch, gStpOrch};
+    m_orchList = { gSwitchOrch, gCrmOrch, gPortsOrch, gBufferOrch, gFlowCounterRouteOrch, gIntfsOrch, gNeighOrch, gNhgMapOrch, gNhgOrch, gCbfNhgOrch, gRouteOrch, gCoppOrch, gQosOrch, wm_orch, gPolicerOrch, gTunneldecapOrch, sflow_orch, gDebugCounterOrch, gMacsecOrch, bgp_global_state_orch, gBfdOrch, gSrv6Orch, gMuxOrch, mux_cb_orch, gMonitorOrch, gStpOrch, gTxErrMonOrch};
 
     bool initialize_dtel = false;
     if (platform == BFN_PLATFORM_SUBSTRING || platform == VS_PLATFORM_SUBSTRING)

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -54,6 +54,7 @@
 #include "dash/dashrouteorch.h"
 #include "dash/dashvnetorch.h"
 #include <sairedis.h>
+#include "txerrmonorch.h"
 
 using namespace swss;
 

--- a/orchagent/txerrmonorch.cpp
+++ b/orchagent/txerrmonorch.cpp
@@ -1,0 +1,140 @@
+#include <linux/if_ether.h>
+
+#include "txerrmonorch.h"
+#include "port.h"
+#include "logger.h"
+#include "sai_serialize.h"
+#include "converter.h"
+
+#include <unordered_map>
+#include <utility>
+#include <exception>
+#include <vector>
+
+extern PortsOrch *gPortsOrch;
+
+TxErrMonOrch::TxErrMonOrch(DBConnector *cfgDbConnector) :
+    Orch(cfgDbConnector, CFG_TX_ERR_TABLE_NAME)
+{
+    SWSS_LOG_ENTER();
+    // Initialize the tables members
+    auto countersDb = std::make_shared<DBConnector>("COUNTERS_DB", 0);
+    m_countersTable = std::make_shared<Table>(countersDb.get(), COUNTERS_TABLE);
+    auto stateDb = std::make_shared<DBConnector>("STATE_DB", 0);
+    m_txErrStateTable = std::make_shared<Table>(stateDb.get(), STATE_TX_ERR_TABLE_NAME);
+
+    // Initialize the config members and table
+    m_period = DEFAULT_TX_ERR_CFG_PERIOD_IN_SEC;
+    m_threshold = DEFAULT_TX_ERR_CFG_THRESHOLD;
+    vector<FieldValueTuple> fvs;
+    fvs.emplace_back(TX_ERR_FIELD_CFG_PERIOD, to_string(m_period));
+    fvs.emplace_back(TX_ERR_FIELD_CFG_THRESHOLD, to_string(m_threshold));
+    auto txErrCfgTable = std::make_shared<Table>(cfgDbConnector, CFG_TX_ERR_TABLE_NAME);
+    txErrCfgTable->set(TX_ERR_FIELD_CFG, fvs);
+
+    // Initialize and start the timer
+    auto interv = timespec { .tv_sec = DEFAULT_TX_ERR_CFG_PERIOD_IN_SEC, .tv_nsec = 0 };
+    m_timer = new SelectableTimer(interv);
+    auto executor = new ExecutableTimer(m_timer, this, TX_ERR_TIMER_NAME);
+    Orch::addExecutor(executor);
+    m_timer->start();
+}
+
+void TxErrMonOrch::doTask(Consumer& consumer)
+{
+    SWSS_LOG_ENTER();
+    try {
+        auto it = consumer.m_toSync.begin();
+        while (it != consumer.m_toSync.end())
+        {
+            KeyOpFieldsValuesTuple t = it->second;
+            string key = kfvKey(t);
+            string op = kfvOp(t);
+            vector<FieldValueTuple> fvs = kfvFieldsValues(t);
+            if (key == TX_ERR_FIELD_CFG)
+            {
+                // If the config values are updated
+                if (op == SET_COMMAND)
+                {
+                    for (const auto &fv : fvs)
+                    {
+                        if (fvField(fv) == TX_ERR_FIELD_CFG_PERIOD)
+                        {
+                            // If the period is updated, reset the timer with the new period
+                            m_period = to_uint<uint32_t>(fvValue(fv));
+                            auto interv = timespec { .tv_sec = m_period, .tv_nsec = 0 };
+                            m_timer->setInterval(interv);
+                            m_timer->reset();
+                            SWSS_LOG_INFO("Update tx err monitoring period to %u seconds", m_period);
+                        }
+                        else if (fvField(fv) == TX_ERR_FIELD_CFG_THRESHOLD)
+                        {
+                            m_threshold = to_uint<uint32_t>(fvValue(fv));
+                            SWSS_LOG_INFO("Update tx err monitoring threshold to %u", m_threshold);
+                        }
+                    }
+                }
+            }
+            consumer.m_toSync.erase(it++);
+        }
+    }
+    catch (...)
+    {
+        SWSS_LOG_ERROR("Failed to handle tx err monitor cfg update\n");
+    }
+}
+
+void TxErrMonOrch::doTask(SelectableTimer &timer)
+{
+    SWSS_LOG_ENTER();
+    fetchTxErrCounters();
+    updatePortStates();
+}
+
+void TxErrMonOrch::fetchTxErrCounters() {
+    SWSS_LOG_ENTER();
+    try
+    {
+        const auto ports = gPortsOrch->getAllPorts();
+        for (const auto &portNameAndObj : ports)
+        {
+            auto portName = portNameAndObj.first;
+            auto portObj = portNameAndObj.second;
+            string portOid = sai_serialize_object_id(portObj.m_port_id);
+            string value;
+            m_countersTable->hget(portOid, TX_ERR_COUNTER_NAME, value);
+            // We found the tx err counter for the port
+            if (!value.empty())
+            {
+                uint64_t newTxErrCount = to_uint<uint64_t>(value);
+                uint64_t oldTxErrCount = m_portToLastTxErrCount[portName];
+                m_portToLastTxErrCount[portName] = newTxErrCount;
+                m_portStatesForUpdate[portName] = ((newTxErrCount - oldTxErrCount) > m_threshold) ? INVALID_STATE : VALID_STATE;
+            }
+        }
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Failed in fetching tx err counters: %s", e.what());
+    }
+}
+
+void TxErrMonOrch::updatePortStates() {
+    SWSS_LOG_ENTER();
+    try
+    {
+        for (const auto &portAndState : m_portStatesForUpdate)
+        {
+            auto portName = portAndState.first;
+            auto state = portAndState.second;
+            vector<FieldValueTuple> fvs;
+            fvs.emplace_back(TX_ERR_FIELD_STATE, state);
+            m_txErrStateTable->set(portName, fvs);
+            SWSS_LOG_INFO("Update state for port %s to %s", portName.c_str(), state.c_str());
+        }
+    }
+    catch (const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Failed in updating port tx err state: %s", e.what());
+    }
+}

--- a/orchagent/txerrmonorch.h
+++ b/orchagent/txerrmonorch.h
@@ -1,0 +1,58 @@
+#ifndef TXERRMONORCH_H
+#define TXERRMONORCH_H
+
+#include "orch.h"
+#include "portsorch.h"
+#include "select.h"
+#include "producerstatetable.h"
+#include "observer.h"
+#include "selectabletimer.h"
+#include "table.h"
+#include "timer.h"
+
+#include <map>
+#include <algorithm>
+#include <tuple>
+#include <inttypes.h>
+
+extern "C" {
+#include "sai.h"
+}
+
+#define TX_ERR_FIELD_CFG "config"
+#define TX_ERR_FIELD_CFG_PERIOD "period"
+#define TX_ERR_FIELD_CFG_THRESHOLD "threshold"
+#define TX_ERR_FIELD_STATE "state"
+#define TX_ERR_COUNTER_NAME "SAI_PORT_STAT_IF_OUT_ERRORS"
+#define TX_ERR_TIMER_NAME "TX_ERR_MONITORING_TIMER"
+#define VALID_STATE "OK"
+#define INVALID_STATE "NOT OK"
+#define DEFAULT_TX_ERR_CFG_PERIOD_IN_SEC 30
+#define DEFAULT_TX_ERR_CFG_THRESHOLD 0
+
+typedef std::unordered_map<std::string, uint64_t> PortToLastTxErrCountMap;
+typedef std::unordered_map<std::string, std::string> PortToTxErrStatesMap;
+
+class TxErrMonOrch : public Orch
+{
+public:
+    TxErrMonOrch(DBConnector *db);
+
+private:
+    virtual void doTask(Consumer &consumer);
+    virtual void doTask(SelectableTimer &timer);
+    void fetchTxErrCounters();
+    void updatePortStates();
+
+    unsigned int m_threshold;
+    unsigned int m_period;
+
+    PortToLastTxErrCountMap m_portToLastTxErrCount;
+    PortToTxErrStatesMap m_portStatesForUpdate;
+    SelectableTimer *m_timer;
+
+    std::shared_ptr<Table> m_countersTable;
+    std::shared_ptr<Table> m_txErrStateTable;
+};
+
+#endif /* TXERRMONORCH_H */

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -145,7 +145,8 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/dash/pbutils.cpp \
                 $(top_srcdir)/cfgmgr/coppmgr.cpp \
                 $(top_srcdir)/orchagent/twamporch.cpp \
-                $(top_srcdir)/orchagent/stporch.cpp
+                $(top_srcdir)/orchagent/stporch.cpp \
+                $(top_srcdir)/orchagent/txerrmonorch.cpp
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp $(FLEX_CTR_DIR)/flow_counter_handler.cpp $(FLEX_CTR_DIR)/flowcounterrouteorch.cpp
 tests_SOURCES += $(DEBUG_CTR_DIR)/debug_counter.cpp $(DEBUG_CTR_DIR)/drop_counter.cpp


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
Created a new class TxErrMonOrch that inherits from Orch to monitor TX error statistics on switch ports. The class listens to changes in the TX_ERR_CFG table to update configuration values such as threshold and period. It also includes a periodic timer to check TX error counts and marks ports as "Not OK" in the TX_ERR_STATE table when error counts exceed the configured threshold within the specified time period.

**Why I did it**
To proactively monitor TX errors on switch ports. If the number of TX errors on a port exceeds a defined threshold within a configurable monitoring period, the port is flagged as "Not OK". 

**How I verified it**
CLI commands:
show interfaces tx-err-monitoring-config
show interfaces tx-err-monitoring-states
config tx-err-monitoring-period 20
config tx-err-monitoring-threshold 1
show interfaces tx-err-monitoring-config
counterpoll port disable
redis-cli -n 2
hget COUNTERS:oid:0x1000000000030 SAI_PORT_STAT_IF_OUT_ERRORS
hset COUNTERS:oid:0x1000000000030 SAI_PORT_STAT_IF_OUT_ERRORS 2
hget COUNTERS:oid:0x1000000000030 SAI_PORT_STAT_IF_OUT_ERRORS
show interfaces tx-err-monitoring-states

**Details if related**
