### PR TITLE
[IM] set port serdes before set admin up (enable TX)

### DIFF
--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -90,6 +90,9 @@ extern bool gMultiAsicVoq;
 #define PG_WATERMARK_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS   60000
 #define PG_DROP_STAT_FLEX_COUNTER_POLLING_INTERVAL_MS   10000
 
+#define NPU_SI_SETTINGS_SYNC_STATUS_KEY   "NPU_SI_SETTINGS_SYNC_STATUS"
+#define NPU_SI_SETTINGS_NOTIFIED_VALUE      "NPU_SI_SETTINGS_NOTIFIED"
+
 // types --------------------------------------------------------------------------------------------------------------
 
 struct PortAttrValue
@@ -5387,6 +5390,34 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 {
                     if (p.m_admin_state_up != pCfg.admin_status.value)
                     {
+                        /*
+                         * When bringing admin UP with no serdes attr in APPL_DB, wait for xcvrd
+                         * to notify SI settings (NPU_SI_SETTINGS_NOTIFIED) so serdes are applied
+                         * before enabling TX. Avoids bad host TX during swss restart.
+                         */
+                        if (pCfg.admin_status.value && serdes_attr.empty())
+                        {
+                            vector<FieldValueTuple> tuples;
+                            bool siExist = m_portStateTable.get(p.m_alias, tuples);
+                            string npuSiStatus;
+                            if (siExist)
+                            {
+                                for (const auto &fv : tuples)
+                                {
+                                    if (fvField(fv) == NPU_SI_SETTINGS_SYNC_STATUS_KEY)
+                                    {
+                                        npuSiStatus = fvValue(fv);
+                                        break;
+                                    }
+                                }
+                            }
+                            if (npuSiStatus != NPU_SI_SETTINGS_NOTIFIED_VALUE)
+                            {
+                                m_pendingPortSet.emplace(pCfg.key);
+                                it++;
+                                continue;
+                            }
+                        }
                         if (!setPortAdminStatus(p, pCfg.admin_status.value))
                         {
                             SWSS_LOG_ERROR(

--- a/tests/mock_tests/bufferorch_ut.cpp
+++ b/tests/mock_tests/bufferorch_ut.cpp
@@ -366,14 +366,17 @@ namespace bufferorch_test
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
 
             Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+            Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
 
             // Get SAI default ports to populate DB
             auto ports = ut_helper::getInitialSaiPorts();
 
             // Populate pot table with SAI ports
+            // Populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
             for (const auto &it : ports)
             {
                 portTable.set(it.first, it.second);
+                statePortTable.set(it.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
             }
 
             // Set PortConfigDone

--- a/tests/mock_tests/copporch_ut.cpp
+++ b/tests/mock_tests/copporch_ut.cpp
@@ -256,14 +256,17 @@ namespace copporch_test
         void initPorts()
         {
             auto portTable = Table(this->appDb.get(), APP_PORT_TABLE_NAME);
+            Table statePortTable(this->stateDb.get(), STATE_PORT_TABLE_NAME);
 
             // Get SAI default ports to populate DB
             auto ports = ut_helper::getInitialSaiPorts();
 
             // Populate port table with SAI ports
+            // Populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
             for (const auto &cit : ports)
             {
                 portTable.set(cit.first, cit.second);
+                statePortTable.set(cit.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
             }
 
             // Set PortConfigDone

--- a/tests/mock_tests/flexcounter_ut.cpp
+++ b/tests/mock_tests/flexcounter_ut.cpp
@@ -372,14 +372,17 @@ namespace flexcounter_test
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
 
             Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+            Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
 
             // Get SAI default ports to populate DB
             auto ports = ut_helper::getInitialSaiPorts();
 
             // Populate pot table with SAI ports
+            // Populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
             for (const auto &it : ports)
             {
                 portTable.set(it.first, it.second);
+                statePortTable.set(it.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
             }
 
             // Set PortConfigDone

--- a/tests/mock_tests/flowcounterrouteorch_ut.cpp
+++ b/tests/mock_tests/flowcounterrouteorch_ut.cpp
@@ -238,15 +238,18 @@ namespace flowcounterrouteorch_test
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
 
             Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+            Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
 
             // Get SAI default ports to populate DB
             auto ports = ut_helper::getInitialSaiPorts();
 
             // Populate pot table with SAI ports
+            // Populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
             for (const auto &it : ports)
             {
                 portTable.set(it.first, it.second);
                 portTable.set(it.first, {{ "oper_status", "up" }});
+                statePortTable.set(it.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
             }
 
             // Set PortConfigDone

--- a/tests/mock_tests/intfsorch_ut.cpp
+++ b/tests/mock_tests/intfsorch_ut.cpp
@@ -227,15 +227,19 @@ namespace intfsorch_test
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
 
             Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+            Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
 
             // Get SAI default ports to populate DB
             auto ports = ut_helper::getInitialSaiPorts();
 
             // Populate pot table with SAI ports
+            // Populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
             for (const auto &it : ports)
             {
                 portTable.set(it.first, it.second);
+                statePortTable.set(it.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
             }
+
             // Set PortConfigDone
             portTable.set("PortConfigDone", { { "count", to_string(ports.size()) } });
             gPortsOrch->addExistingData(&portTable);

--- a/tests/mock_tests/mock_orch_test.cpp
+++ b/tests/mock_tests/mock_orch_test.cpp
@@ -1,4 +1,5 @@
 #include "mock_orch_test.h"
+#include "mock_table.h"
 
 using namespace std;
 
@@ -129,6 +130,14 @@ void MockOrchTest::SetUp()
     gDirectory.set(gPortsOrch);
     ut_orch_list.push_back((Orch **)&gPortsOrch);
     global_orch_list.insert((Orch **)&gPortsOrch);
+
+    // Pre-populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
+    Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
+    auto ports = ut_helper::getInitialSaiPorts();
+    for (const auto &it : ports)
+    {
+        statePortTable.set(it.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
+    }
 
     const int fgnhgorch_pri = 15;
 

--- a/tests/mock_tests/portphyattr_ut.cpp
+++ b/tests/mock_tests/portphyattr_ut.cpp
@@ -115,10 +115,13 @@ namespace portphyattr_test
 
             // Initialize ports using SAI default ports
             Table portTable(m_app_db.get(), APP_PORT_TABLE_NAME);
+            Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
             auto ports = ut_helper::getInitialSaiPorts();
             for (const auto &it : ports)
             {
                 portTable.set(it.first, it.second);
+                // Populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
+                statePortTable.set(it.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
             }
 
             // Set PortConfigDone

--- a/tests/mock_tests/portsorch_ut.cpp
+++ b/tests/mock_tests/portsorch_ut.cpp
@@ -559,6 +559,13 @@ namespace portsorch_test
 
             gPortsOrch = new PortsOrch(m_app_db.get(), m_state_db.get(), ports_tables, m_chassis_app_db.get());
 
+            // Populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
+            Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
+            for (const auto &it : defaultPortList)
+            {
+                statePortTable.set(it.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
+            }
+
             vector<string> flex_counter_tables = {
                 CFG_FLEX_COUNTER_TABLE_NAME
             };
@@ -1030,6 +1037,15 @@ namespace portsorch_test
 
         // Set PortConfigDone
         portTable.set("PortConfigDone", { { "count", std::to_string(ports.size()) } });
+
+        // Set NPU_SI_SETTINGS_SYNC_STATUS to NOTIFIED for each port so PortsOrch does not defer admin up
+        Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
+        for (std::uint32_t idx1 = 0; idx1 < ports.size() * 4; idx1 += 4)
+        {
+            std::stringstream key;
+            key << FRONT_PANEL_PORT_PREFIX << idx1;
+            statePortTable.set(key.str(), {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
+        }
 
         // Refill consumer
         gPortsOrch->addExistingData(&portTable);

--- a/tests/mock_tests/qosorch_ut.cpp
+++ b/tests/mock_tests/qosorch_ut.cpp
@@ -461,14 +461,17 @@ namespace qosorch_test
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
 
             Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+            Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
 
             // Get SAI default ports to populate DB
             auto ports = ut_helper::getInitialSaiPorts();
 
             // Populate pot table with SAI ports
+            // Populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
             for (const auto &it : ports)
             {
                 portTable.set(it.first, it.second);
+                statePortTable.set(it.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
             }
 
             // Set PortConfigDone

--- a/tests/mock_tests/routeorch_ut.cpp
+++ b/tests/mock_tests/routeorch_ut.cpp
@@ -325,15 +325,18 @@ namespace routeorch_test
             gBufferOrch = new BufferOrch(m_app_db.get(), m_config_db.get(), m_state_db.get(), buffer_tables);
 
             Table portTable = Table(m_app_db.get(), APP_PORT_TABLE_NAME);
+            Table statePortTable(m_state_db.get(), STATE_PORT_TABLE_NAME);
 
             // Get SAI default ports to populate DB
             auto ports = ut_helper::getInitialSaiPorts();
 
             // Populate pot table with SAI ports
+            // Populate STATE_DB so PortsOrch does not defer admin up waiting for NPU_SI_SETTINGS_NOTIFIED
             for (const auto &it : ports)
             {
                 portTable.set(it.first, it.second);
                 portTable.set(it.first, {{ "oper_status", "up" }});
+                statePortTable.set(it.first, {{"NPU_SI_SETTINGS_SYNC_STATUS", "NPU_SI_SETTINGS_NOTIFIED"}});
             }
 
             // Set PortConfigDone


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**
When bringing a port admin up with no serdes in APPL_DB,
PortsOrch now checks STATE_DB for NPU_SI_SETTINGS_SYNC_STATUS
and defers setting admin up until it is NPU_SI_SETTINGS_NOTIFIED.
If not NOTIFIED, the port is left in m_pendingPortSet and will be retried on the next doTask.

**Why I did it**
On swss restart, PortsOrch (swss) can run before xcvrd (pmon).
PortsOrch then sets admin up using whatever is in APPL_DB (no serdes yet),
so TX is enabled with wrong/default serdes.
That causes a short period of bad host TX and can lead to RX/TX CDR LoL on some modules (e.g. AOI 200G).
By deferring admin up until xcvrd has signaled NOTIFIED (serdes published or “no media settings”),
we apply serdes before enabling TX and avoid that bad period.

**How I verified it**
1. Setup/Connections: AOI module Y cable (2X200):
Ethernet32 etp5a QSFP-DD (4 lanes out of 8)
Ethernet36 etp5b  QSFP-DD  (4 lanes out of 8)
Ethernet40 etp6 QSFP+ (4 lanes)
Ethernet48 etp7 QSFP+ (4 lanes)
2. Configure SW CTRL (IM)
3. Verify admin+oper are UP
4. systemctl restart swss
5. Verify admin+oper

**Details if related**
